### PR TITLE
arr_Filter単位で条件指定するよう変更

### DIFF
--- a/include/collections/array.h
+++ b/include/collections/array.h
@@ -1,6 +1,7 @@
 #ifndef arr_COLLECTIONS_ARRAY_H
 #define arr_COLLECTIONS_ARRAY_H
 
+#include "type.h"
 #include "bool.h"
 #include <stdio.h>
 
@@ -28,12 +29,15 @@ arr_Array *arr_cleanup(arr_Array *arr);
 c_Bool arr_contain(arr_Array *arr, void *elem);
 int arr_map(arr_Array *arr, arr_Callback f);
 
+typedef int (*arr_Matcher)(unsigned int index, const void *elem, c_TypeUnion cond, void *user_data);
+
 typedef struct arr_Filter {
-    arr_Callback func;
+    arr_Matcher matcher;
+    c_TypeUnion cond;
     unsigned int index;
 } arr_Filter;
 
-arr_Filter *arr_set_filter(arr_Filter *filter, arr_Callback func);
+arr_Filter *arr_set_filter(arr_Filter *filter, arr_Matcher matcher, c_TypeUnion cond);
 void *arr_next(arr_Filter *filter, const arr_Array *arr);
 
 #endif

--- a/src/array.c
+++ b/src/array.c
@@ -359,14 +359,15 @@ int arr_map(arr_Array *arr, arr_Callback f)
 }
 
 
-arr_Filter *arr_set_filter(arr_Filter *filter, arr_Callback func)
+arr_Filter *arr_set_filter(arr_Filter *filter, arr_Matcher matcher, c_TypeUnion cond)
 {
-	if (filter == NULL || func == NULL) {
+	if (filter == NULL || matcher == NULL) {
 		return NULL;
 	}
 
-	filter->func = func;
+	filter->matcher = matcher;
 	filter->index = 0;
+	filter->cond = cond;
 
 	return filter;
 }
@@ -375,20 +376,20 @@ arr_Filter *arr_set_filter(arr_Filter *filter, arr_Callback func)
 void *arr_next(arr_Filter *filter, const arr_Array *arr)
 {
 	void *v;
-	arr_Callback f;
+	arr_Matcher m;
 	unsigned int i;
 
 	if (filter == NULL || arr == NULL) {
 		return NULL;
 	}
 
-	f = filter->func;
+	m = filter->matcher;
 	for (i = filter->index; i < arr->len; i++) {
 		void *v = arr_get(arr, i);
 		if (v == NULL) {
 			return NULL;
 		}
-		if ((*f)(i, v, arr->user_data) == 1) {
+		if ((*m)(i, v, filter->cond, arr->user_data) == 1) {
 			filter->index = i + 1;
 
 			return v;


### PR DESCRIPTION
これまで`arr_Array`をフィルタリングする際は、`arr_Filter`に渡す`arr_Callback`内で条件指定を行う必要があり、`arr_Callback`単位での条件指定をなっていた。

本PRでは`arr_Filter`内に条件値（`cond`）を持ち、さらに`arr_Callback`の代わりに`arr_Matcher`を使用することで、`arr_Filter`単位での条件指定が行えるように変更する。
（`arr_Matcher`では、ある要素について`cond`と一致するかを判定する。）